### PR TITLE
Fix "Invalid cross-device link"

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -989,7 +989,7 @@ render <- function(input,
     if (!is.null(intermediates_dir)) {
       intermediate_output <- file.path(intermediates_dir, basename(output_file))
       if (file.exists(intermediate_output)) {
-        file.rename(intermediate_output, output_file)
+        file.copy(intermediate_output, output_file) && unlink(intermediate_output)
       }
     }
 


### PR DESCRIPTION
When tempdir() is used for intermediates_dir, this error can occur on Linux systems.